### PR TITLE
Update tsd to fix type tests

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+/coverage/
+/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:
 	@echo
 
 lint:
-	@jshint --exclude '**/{coverage,node_modules}/*' **/*.js
+	@$(BIN)/jshint .
 
 test: node_modules
 	$(if $(npm_config_grep), @echo "Running test files that match pattern: $(npm_config_grep)\n",)
@@ -39,7 +39,7 @@ test-types: node_modules
 
 npm-test: lint test check-cover test-types
 
-travis-test: lint test check-cover
+travis-test: npm-test
 	@(cat coverage/lcov.info | coveralls) || exit 0
 
 check-cover: coverage

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   },
   "contributors": [],
   "devDependencies": {
-    "@types/node": "^15.3.0",
+    "@types/node": "*",
     "istanbul": "~0.2.8",
     "jshint": "^2.5.6",
     "tap-dot": "^0.2.2",
     "tap-spec": "~0.1.9",
     "tape": "~4.0.1",
     "through2": "^0.6.3",
-    "tsd": "^0.16.0"
+    "tsd": "^0.25.0"
   },
   "dependencies": {
     "promise-polyfill": "^1.1.6"

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,7 +1,7 @@
 import { expectType } from "tsd";
 import streamToString = require("..");
 
-const stream = null as any as NodeJS.ReadableStream;
+declare const stream: NodeJS.ReadableStream;
 
 // test type exports
 type CB = streamToString.Callback;


### PR DESCRIPTION
- use more sensible version for node types
- only lint project files
- use jshint from node_modules instead of the global one

Fix #6